### PR TITLE
Allow dnsConfig to be overridden in `ipi-conf-debug-kdump-gather-logs`

### DIFF
--- a/ci-operator/step-registry/ipi/conf/debug/kdump-gather-logs/ipi-conf-debug-kdump-gather-logs-ref.yaml
+++ b/ci-operator/step-registry/ipi/conf/debug/kdump-gather-logs/ipi-conf-debug-kdump-gather-logs-ref.yaml
@@ -7,6 +7,7 @@ ref:
     requests:
       cpu: 300m
       memory: 300Mi
+  dnsConfig: {}
   env:
   - name: APPLY_NODE_ROLE
     default: "worker"

--- a/ci-operator/step-registry/ipi/libvirt/post/ipi-libvirt-post-chain.yaml
+++ b/ci-operator/step-registry/ipi/libvirt/post/ipi-libvirt-post-chain.yaml
@@ -2,12 +2,6 @@ chain:
   as: ipi-libvirt-post
   steps:
   - ref: ipi-conf-debug-kdump-gather-logs
-    dnsConfig:
-      nameservers:
-      - 172.30.38.188
-      searches:
-      - "bastion-z.svc.cluster.local"
-      - "bastion-ppc64le-libvirt.svc.cluster.local"
   - ref: gather-libvirt
   - ref: ipi-deprovision-deprovision-libvirt
   documentation: |-


### PR DESCRIPTION
I understand it may be counter intuitive but steps of chain are either defined literally or referenced with `ref`. It's not possible to reference an existing step like and override one of its fields at the same time, e.g.:
```yaml
chain:
  as: ipi-libvirt-post
  steps:
  - ref: ipi-conf-debug-kdump-gather-logs
    dnsConfig:
      nameservers:
      - 172.30.38.188
      searches:
      - "bastion-z.svc.cluster.local"
      - "bastion-ppc64le-libvirt.svc.cluster.local"
```

Once the `dnsConfig` is set to empty at the step level, the workflow `openshift-e2e-libvirt` will be able to override it thanks to the feature we added with https://github.com/openshift/ci-tools/pull/3687.